### PR TITLE
Player shadows are now offset correctly by draw_x and draw_y variables

### DIFF
--- a/scripts/article13_draw.gml
+++ b/scripts/article13_draw.gml
@@ -30,7 +30,7 @@ switch(type)
         
         with(oPlayer)
         {
-            draw_sprite_ext(sprite_index, image_index, x, y, spr_dir*visible*(1+small_sprites), visible*(1+small_sprites), image_angle+spr_angle, c_white, 1);
+            draw_sprite_ext(sprite_index, image_index, x + draw_x, y + draw_y, spr_dir*visible*(1+small_sprites), visible*(1+small_sprites), image_angle+spr_angle, c_white, 1);
         }
         with(obj_stage_article)
         {


### PR DESCRIPTION
This was a simple enough change that I thought I might as well do it myself :) It also seemed like good practice to learn how to fork projects and make pull requests, since I haven't done this before. I hope I'm not overstepping here by doing this! 😅

Change is just one line of code, since this is the only place I've found that seems to be relevant. Here is what happened when it drew the shadow of a character whose draw_x or draw_y values weren't 0 before the change:
![image](https://user-images.githubusercontent.com/49110090/140181648-3ea50c35-0015-49e2-8a4e-b6e37b626ad5.png)

Here's what it looks like now:
![image](https://user-images.githubusercontent.com/49110090/140181668-24e8a60f-52a4-4c31-9c6d-f4ea0dfb5dcc.png)