### PR TITLE
Hitting enemies/destructible terrain with projectiles no longer puts player in hitpause

### DIFF
--- a/scripts/article15_update.gml
+++ b/scripts/article15_update.gml
@@ -41,12 +41,16 @@ if !_init {
             sound_play(sound_effect);
             spawn_hit_fx(x+hit_effect_x,y+hit_effect_y,hit_effect);
             with player_id {
-                old_hsp = hsp;
-                old_vsp = vsp;
                 
                 has_hit = true;
-                hitstop = other.hitpause+other.damage*other.hitpause_growth*.05-2;
-                hitpause = true;
+                
+                if(collis.type == 1) {
+	                old_hsp = hsp;
+	                old_vsp = vsp;
+	                hsp = 0; vsp = 0;
+	                hitstop = other.hitpause+other.damage*other.hitpause_growth*.05-2;
+	                hitpause = true;
+                }
             }
         }
         destroyed = true;

--- a/scripts/article6_update.gml
+++ b/scripts/article6_update.gml
@@ -1488,7 +1488,7 @@ with _hbox {
         }
         other.percent += damage*other.percent_adj;
         other.kb_power = kb_value+other.percent*0.12*kb_scale*other.knockback_adj;
-        other.hitpause = hitpause + other.percent*hitpause_growth*0.05;
+        other.hitpause = hitpause + other.percent*hitpause_growth*0.05 + extra_hitpause;
         other.old_hsp = other.hsp;
         other.old_vsp = other.vsp;
         if no_other_hit != 0 other.hit_lockout = no_other_hit;
@@ -1519,12 +1519,14 @@ kb_angle = get_hitbox_angle(_hbox) + di_angle_max - random_func(floor(x) % 200, 
 if _hbox.player_id != 0 with _hbox.player_id {
     has_hit = 1;
     has_hbox = other.id;
-    old_vsp = vsp;
-    old_hsp = hsp;
-    hitstop = other.hitpause;
-    hitpause = 1;
-    hsp = 0;
-    vsp = 0;
+    if(_hbox.type == 1) {
+	    old_vsp = vsp;
+	    old_hsp = hsp;
+	    hitstop = min(1, other.hitpause - _hbox.extra_hitpause);
+	    hitpause = 1;
+	    hsp = 0;
+	    vsp = 0;
+    }
 }
 
 


### PR DESCRIPTION
Pretty small and straightforward change. I also made it so that enemies will respect the `HG_EXTRA_HITPAUSE` grid index. This just adds the value to the amount of hitpause that the enemy takes; it's then subtracted again when calculating how long the attacking player should enter hitpause. This is a dumb way to do it but it's easy, functional, and doesn't have a meaningful performance cost so 🤷‍♀️

Destructible terrain doesn't check for extra hitpause at all, because it never enters hitpause, from what I could tell.